### PR TITLE
Add {$WEB_ROOT}/ to style.css and base.js URIs

### DIFF
--- a/common.tpl
+++ b/common.tpl
@@ -1,5 +1,5 @@
-<link rel="stylesheet" type="text/css" href="templates/orderforms/standard_cart/style.css" />
+<link rel="stylesheet" type="text/css" href="{$WEB_ROOT}/templates/orderforms/standard_cart/style.css" />
 <link href="{$BASE_PATH_CSS}/icheck/square/blue.css" rel="stylesheet">
 <link href="{$BASE_PATH_CSS}/icheck/square/green.css" rel="stylesheet">
 <script type="text/javascript" src="{$BASE_PATH_JS}/icheck.js"></script>
-<script type="text/javascript" src="templates/orderforms/standard_cart/base.js"></script>
+<script type="text/javascript" src="{$WEB_ROOT}/templates/orderforms/standard_cart/base.js"></script>


### PR DESCRIPTION
We use a bit of .htaccess magic to enable SEO-friendly URLs for our order pages, and without this change, this ordering template is unusable (404 for style.css and base.js).
This little change makes URLs work correctly.
