### PR TITLE
Add "Free" service support

### DIFF
--- a/domainregister.tpl
+++ b/domainregister.tpl
@@ -221,22 +221,28 @@
                                     {if current($price.register) >= 0}
                                         {current($price.register)}<br>
                                         <small>{key($price.register)} {if key($price.register) > 1}{lang key="orderForm.years"}{else}{lang key="orderForm.year"}{/if}</small>
+				    {else if current($price.register) == 0}
+					<small>FREE!</small>
                                     {else}
                                         <small>N/A</small>
                                     {/if}
                                 </div>
                                 <div class="col-xs-4 text-center">
                                     {if current($price.transfer) > 0}
-                                        {current($price.transfer)}<br>
-                                        <small>{key($price.transfer)} {if key($price.register) > 1}{lang key="orderForm.years"}{else}{lang key="orderForm.year"}{/if}</small>
-                                    {else}
-                                        <small>N/A</small>
-                                    {/if}
+					{current($price.transfer)}<br>
+					<small>{key($price.transfer)} {if key($price.register) > 1}{lang key="orderForm.years"}{else}{lang key="orderForm.year"}{/if}</small>
+				    {else if current($price.transfer) == 0}
+				        <small>FREE!</small>
+				    {else}
+					<small>N/A</small>
+				    {/if}
                                 </div>
                                 <div class="col-xs-4 text-center">
                                     {if current($price.renew) > 0}
                                         {current($price.renew)}<br>
                                         <small>{key($price.renew)} {if key($price.register) > 1}{lang key="orderForm.years"}{else}{lang key="orderForm.year"}{/if}</small>
+				    {else if current($price.renew) == 0}
+					<small>FREE!</small>
                                     {else}
                                         <small>N/A</small>
                                     {/if}


### PR DESCRIPTION
Added support for services that are valued at 0.00/Free. The pricing table will no longer specify "N/A" for free services which may cause confusion and belief that a service is unavailable. It will now show "FREE!" instead.