### PR TITLE
Replace hard references to "standard_cart" path with $carttpl

### DIFF
--- a/adddomain.tpl
+++ b/adddomain.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
 
@@ -20,13 +20,13 @@
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             {if $domain == 'register'}
                 <p>{$LANG.orderForm.findNewDomain}</p>

--- a/addons.tpl
+++ b/addons.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
 
@@ -14,13 +14,13 @@
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             {if count($addons) == 0}
                 <div class="alert alert-warning text-center" role="alert">

--- a/checkout.tpl
+++ b/checkout.tpl
@@ -4,7 +4,7 @@
     // Do not enforce state input client side
     var stateNotRequired = true;
 </script>
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 <script type="text/javascript" src="{$BASE_PATH_JS}/StatesDropdown.js"></script>
 <script type="text/javascript" src="{$BASE_PATH_JS}/PasswordStrength.js"></script>
 <script>
@@ -45,13 +45,13 @@
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <div class="already-registered clearfix">
                 <div class="pull-right">
@@ -104,13 +104,13 @@
                         </div>
                     </div>
 
-                    {include file="orderforms/standard_cart/linkedaccounts.tpl" linkContext="checkout-existing"}
+                    {include file="orderforms/{$carttpl}/linkedaccounts.tpl" linkContext="checkout-existing"}
                 </div>
 
                 <div id="containerNewUserSignup">
 
                     <div{if $loggedin || $custtype eq "existing"} class="hidden"{/if}>
-                        {include file="orderforms/standard_cart/linkedaccounts.tpl" linkContext="checkout-new"}
+                        {include file="orderforms/{$carttpl}/linkedaccounts.tpl" linkContext="checkout-new"}
                     </div>
 
                     <div class="sub-heading">

--- a/common.tpl
+++ b/common.tpl
@@ -1,2 +1,2 @@
-<link rel="stylesheet" type="text/css" href="{$WEB_ROOT}/templates/orderforms/standard_cart/css/all.min.css?v={$versionHash}" />
-<script type="text/javascript" src="{$WEB_ROOT}/templates/orderforms/standard_cart/js/scripts.min.js?v={$versionHash}"></script>
+<link rel="stylesheet" type="text/css" href="{$WEB_ROOT}/templates/orderforms/{$carttpl}/css/all.min.css?v={$versionHash}" />
+<script type="text/javascript" src="{$WEB_ROOT}/templates/orderforms/{$carttpl}/js/scripts.min.js?v={$versionHash}"></script>

--- a/complete.tpl
+++ b/complete.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
 
@@ -14,13 +14,13 @@
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <p>{$LANG.orderreceived}</p>
 

--- a/configuredomains.tpl
+++ b/configuredomains.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <script>
 var _localLang = {
@@ -21,13 +21,13 @@ var _localLang = {
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <form method="post" action="{$smarty.server.PHP_SELF}?a=confdomains" id="frmConfigureDomains">
                 <input type="hidden" name="update" value="true" />

--- a/configureproduct.tpl
+++ b/configureproduct.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <script>
 var _localLang = {
@@ -21,13 +21,13 @@ var _localLang = {
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <form id="frmConfigureProduct">
                 <input type="hidden" name="configure" value="true" />

--- a/configureproductdomain.tpl
+++ b/configureproductdomain.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
 
@@ -14,13 +14,13 @@
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <form id="frmProductDomain">
                 <input type="hidden" id="frmProductDomainPid" value="{$pid}" />

--- a/domain-renewals.tpl
+++ b/domain-renewals.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
     <div class="row">
@@ -19,13 +19,13 @@
         </div>
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <div class="row">
 

--- a/domainregister.tpl
+++ b/domainregister.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
 
@@ -16,13 +16,13 @@
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <p>{$LANG.orderForm.findNewDomain}</p>
 

--- a/domainrenewals.tpl
+++ b/domainrenewals.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
 
@@ -14,13 +14,13 @@
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <p>{$LANG.domainrenewdesc}</p>
 

--- a/domaintransfer.tpl
+++ b/domaintransfer.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
 
@@ -16,13 +16,13 @@
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <div class="text-center">
                 <h2>{lang key='orderForm.transferToUs'}</h2>

--- a/error.tpl
+++ b/error.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
 
@@ -16,13 +16,13 @@
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <div class="alert alert-danger error-heading">
                 <i class="fas fa-exclamation-triangle"></i>

--- a/fraudcheck.tpl
+++ b/fraudcheck.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
 
@@ -12,7 +12,7 @@
 
         <div class="col-md-10 col-md-offset-1">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             <div class="alert alert-danger error-heading">
                 <i class="fas fa-exclamation-triangle"></i>

--- a/products.tpl
+++ b/products.tpl
@@ -1,4 +1,4 @@
-{include file="orderforms/standard_cart/common.tpl"}
+{include file="orderforms/{$carttpl}/common.tpl"}
 
 <div id="order-standard_cart">
 
@@ -26,12 +26,12 @@
         </div>
 
         <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
-            {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
         </div>
 
         <div class="col-md-9 pull-md-right">
 
-            {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+            {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
             {foreach $hookAboveProductsOutput as $output}
                 <div>

--- a/viewcart.tpl
+++ b/viewcart.tpl
@@ -9,7 +9,7 @@
         var statesTab = 10;
         var stateNotRequired = true;
     </script>
-    {include file="orderforms/standard_cart/common.tpl"}
+    {include file="orderforms/{$carttpl}/common.tpl"}
     <script type="text/javascript" src="{$BASE_PATH_JS}/StatesDropdown.js"></script>
 
     <div id="order-standard_cart">
@@ -26,13 +26,13 @@
 
             <div class="col-md-3 pull-md-left sidebar hidden-xs hidden-sm">
 
-                {include file="orderforms/standard_cart/sidebar-categories.tpl"}
+                {include file="orderforms/{$carttpl}/sidebar-categories.tpl"}
 
             </div>
 
             <div class="col-md-9 pull-md-right">
 
-                {include file="orderforms/standard_cart/sidebar-categories-collapsed.tpl"}
+                {include file="orderforms/{$carttpl}/sidebar-categories-collapsed.tpl"}
 
                 <div class="row">
                     <div class="col-md-8">


### PR DESCRIPTION
Hi,

The hard coded references to "standard_cart" are not a good idea, it makes it more difficult to extend and edit the theme. For example, I edited our `includes/sidebar.tpl` file to remove the `panel-minimise` icon from the right hand side of the sidebar headers. However this change wouldn't apply because the hard coded paths in each template reference the original theme name "standard_cart" rather than my forked version. I had to instead make the changes in this PR but that shouldn't be necessary for someone editing small parts of the theme.

I hope you consider making this change to make life a bit easier for developers. Less deviations from the 'master' theme means less conflicts etc on each version upgrade.

Thanks,
Mike