### PR TITLE
Repair "Give me more suggestions!" link when registering domain

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -3824,7 +3824,7 @@ function loadMoreSuggestions()
             suggestions.find('div.domain-suggestion.clone:hidden:first').slideDown();
             furtherSuggestions = suggestions.find('div.domain-suggestion.clone:hidden').length;
         } else {
-            jQuery('div.more-suggestions').find('a').addClass('hidden').end().find('span.no-more').removeClass('hidden');
+            jQuery('div.more-suggestions').find('a').addClass('w-hidden').end().find('span.no-more').removeClass('w-hidden').show();
             return;
         }
     }


### PR DESCRIPTION
When registering a domain, after the first 10 suggestions have loaded, there's a link that says "Give me more suggestion!" however if there are no more suggestions available, when you click it, it does nothing. This repairs that issue.